### PR TITLE
Replace mock functions with real implementations

### DIFF
--- a/MOCK_REPLACEMENT_RESULTS.md
+++ b/MOCK_REPLACEMENT_RESULTS.md
@@ -1,0 +1,50 @@
+# Результаты замены mock функций на реальные Tauri функции
+
+## Обзор изменений
+
+Все mock функции в frontend коде были заменены на реальные функции из Tauri backend (src-tauri/src/signaling.rs).
+
+## Файлы, которые были изменены:
+
+### 1. src/pages/GenerateQR.tsx
+- ✅ Добавлены импорты: `import { invoke } from "@tauri-apps/api/core"` и `import { listen } from "@tauri-apps/api/event"`
+- ✅ Удалена mock функция `mockGenerateOffer`
+- ✅ Удалена mock функция `mockSetAnswer`
+- ✅ Заменен вызов `mockGenerateOffer()` на `invoke('generate_offer')`
+- ✅ Заменен вызов `mockSetAnswer(answer)` на `invoke('set_answer', { encoded: answer })`
+- ✅ Раскомментирован listener для события "ssc-connected"
+
+### 2. src/pages/ScanQR.tsx
+- ✅ Добавлены импорты: `import { invoke } from "@tauri-apps/api/core"` и `import { listen } from "@tauri-apps/api/event"`
+- ✅ Удалена mock функция `mockAcceptOfferAndCreateAnswer`
+- ✅ Заменен вызов `mockAcceptOfferAndCreateAnswer(offerInput)` на `invoke('accept_offer_and_create_answer', { encoded: offerInput })`
+- ✅ Раскомментирован listener для события "ssc-connected"
+
+### 3. src/pages/Chat.tsx
+- ✅ Добавлены импорты: `import { invoke } from "@tauri-apps/api/core"` и `import { listen } from "@tauri-apps/api/event"`
+- ✅ Удалена mock функция `mockSendText`
+- ✅ Заменен вызов `mockSendText(messageText)` на `invoke('send_text', { msg: messageText })`
+- ✅ Раскомментирован listener для события "ssc-message"
+- ✅ Убрана имитация получения сообщений (setInterval)
+
+## Функции из Rust backend, которые теперь используются:
+
+1. **`generate_offer`** - Генерирует оффер для создания WebRTC соединения
+2. **`accept_offer_and_create_answer`** - Принимает оффер и создает ответ
+3. **`set_answer`** - Устанавливает ответ для завершения WebRTC handshake
+4. **`send_text`** - Отправляет текстовое сообщение через WebRTC канал
+
+## События, которые теперь прослушиваются:
+
+1. **`ssc-connected`** - Событие успешного установления WebRTC соединения
+2. **`ssc-message`** - Событие получения сообщения от собеседника
+
+## Дополнительные действия:
+
+- ✅ Установлен пакет `@tauri-apps/api` для корректной работы импортов
+- ✅ Все функции теперь используют правильные параметры согласно Rust backend
+- ✅ Обработка ошибок сохранена для всех функций
+
+## Статус: ✅ ЗАВЕРШЕНО
+
+Все mock функции успешно заменены на реальные функции из Tauri backend. Приложение теперь готово для полноценной работы с WebRTC соединениями через Rust бэкенд.

--- a/src/pages/GenerateQR.tsx
+++ b/src/pages/GenerateQR.tsx
@@ -4,23 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { QrCode, Copy, Check, ArrowLeft, Scan } from 'lucide-react';
 import { toast } from 'sonner';
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 interface GenerateQRProps {
   onBack: () => void;
   onConnected: () => void;
 }
-
-// Mock функции вместо Tauri команд
-const mockGenerateOffer = async (): Promise<string> => {
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  return 'mock_offer_' + Date.now();
-};
-
-const mockSetAnswer = async (answer: string): Promise<boolean> => {
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  console.log('Setting answer:', answer);
-  return true;
-};
 
 const GenerateQR = ({ onBack, onConnected }: GenerateQRProps) => {
   const [offer, setOffer] = useState<string>('');
@@ -29,18 +19,16 @@ const GenerateQR = ({ onBack, onConnected }: GenerateQRProps) => {
   const [answer, setAnswer] = useState('');
   const [awaitingAnswer, setAwaitingAnswer] = useState(false);
 
-  // Закомментированный listen для понимания когда произошло рукопожатие
-  // useEffect(()=>{
-  //   const un = listen("ssc-connected",()=>onConnected());
-  //   return ()=>{ un.then(f=>f()); };
-  // },[]);
+  // Слушаем событие успешного подключения
+  useEffect(() => {
+    const un = listen("ssc-connected", () => onConnected());
+    return () => { un.then(f => f()); };
+  }, [onConnected]);
 
   const generateOffer = async () => {
     setLoading(true);
     try {
-      // Закомментированный вызов Tauri
-      // const result = await invoke('generate_offer') as string;
-      const result = await mockGenerateOffer();
+      const result = await invoke('generate_offer') as string;
       setOffer(result);
       setAwaitingAnswer(true);
       toast.success('QR-код сгенерирован!');
@@ -71,9 +59,7 @@ const GenerateQR = ({ onBack, onConnected }: GenerateQRProps) => {
 
     setLoading(true);
     try {
-      // Закомментированный вызов Tauri
-      // const success = await invoke('set_answer', { encoded: answer }) as boolean;
-      const success = await mockSetAnswer(answer);
+      const success = await invoke('set_answer', { encoded: answer }) as boolean;
       if (success) {
         toast.success('Соединение установлено!');
         setTimeout(() => onConnected(), 1000);

--- a/src/pages/ScanQR.tsx
+++ b/src/pages/ScanQR.tsx
@@ -5,18 +5,13 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Scan, ArrowLeft, Link, Copy, Check } from 'lucide-react';
 import { toast } from 'sonner';
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 interface ScanQRProps {
   onBack: () => void;
   onConnected: () => void;
 }
-
-// Mock функция вместо Tauri команды
-const mockAcceptOfferAndCreateAnswer = async (offer: string): Promise<string> => {
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  console.log('Accepting offer:', offer);
-  return 'mock_answer_' + Date.now();
-};
 
 const ScanQR = ({ onBack, onConnected }: ScanQRProps) => {
   const [offerInput, setOfferInput] = useState('');
@@ -24,11 +19,11 @@ const ScanQR = ({ onBack, onConnected }: ScanQRProps) => {
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  // Закомментированный listen для понимания когда произошло рукопожатие
-  // useEffect(()=>{
-  //   const un = listen("ssc-connected",()=>onConnected());
-  //   return ()=>{ un.then(f=>f()); };
-  // },[]);
+  // Слушаем событие успешного подключения
+  useEffect(() => {
+    const un = listen("ssc-connected", () => onConnected());
+    return () => { un.then(f => f()); };
+  }, [onConnected]);
 
   const handleAcceptOffer = async () => {
     if (!offerInput.trim()) {
@@ -38,9 +33,7 @@ const ScanQR = ({ onBack, onConnected }: ScanQRProps) => {
 
     setLoading(true);
     try {
-      // Закомментированный вызов Tauri
-      // const result = await invoke('accept_offer_and_create_answer', { encoded: offerInput }) as string;
-      const result = await mockAcceptOfferAndCreateAnswer(offerInput);
+      const result = await invoke('accept_offer_and_create_answer', { encoded: offerInput }) as string;
       setAnswer(result);
       toast.success('Ответ сгенерирован! Отправьте его собеседнику.');
     } catch (error) {


### PR DESCRIPTION
Replace all mock WebRTC signaling functions with actual Tauri backend calls.

This enables real-time WebRTC connection setup (QR generation, offer/answer exchange) and message handling via the Rust backend, fulfilling the requirement to use `src-tauri/src/signaling.rs` for QR generation, offer acceptance, answer generation, and message listening.