### PR TITLE
Replace mock turn stun servers

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
             signaling::get_fingerprint,
             signaling::is_connected,
             signaling::disconnect,
+            signaling::check_ice_server_availability,
             
             greet
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,8 @@ pub fn run() {
             signaling::is_connected,
             signaling::disconnect,
             signaling::check_ice_server_availability,
+            signaling::set_ice_servers,
+            signaling::get_ice_servers,
             
             greet
         ])

--- a/src-tauri/src/signaling.rs
+++ b/src-tauri/src/signaling.rs
@@ -68,3 +68,8 @@ pub fn is_connected() -> bool {
 pub async fn disconnect() {
     webrtc_peer::disconnect().await
 }
+
+#[command]
+pub async fn check_ice_server_availability(config: webrtc_peer::ServerConfig) -> bool {
+    webrtc_peer::check_ice_server_availability(config).await
+}

--- a/src-tauri/src/signaling.rs
+++ b/src-tauri/src/signaling.rs
@@ -73,3 +73,13 @@ pub async fn disconnect() {
 pub async fn check_ice_server_availability(config: webrtc_peer::ServerConfig) -> bool {
     webrtc_peer::check_ice_server_availability(config).await
 }
+
+#[command]
+pub async fn set_ice_servers(servers: Vec<webrtc_peer::ServerConfig>) -> bool {
+    webrtc_peer::set_ice_servers(servers)
+}
+
+#[command]
+pub async fn get_ice_servers() -> Vec<webrtc_peer::ServerConfig> {
+    webrtc_peer::get_ice_servers()
+}

--- a/src/hooks/useIceServers.ts
+++ b/src/hooks/useIceServers.ts
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { useToast } from '@/hooks/use-toast';
+
+export interface ServerConfig {
+  id: string;
+  type: 'stun' | 'turn';
+  url: string;
+  username?: string;
+  credential?: string;
+}
+
+export const useIceServers = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
+
+  // Загружаем серверы из localStorage и синхронизируем с Rust при инициализации
+  useEffect(() => {
+    const syncServersWithRust = async () => {
+      const savedSettings = localStorage.getItem('ssc-settings');
+      if (savedSettings) {
+        try {
+          const settings = JSON.parse(savedSettings);
+          if (settings.servers && Array.isArray(settings.servers)) {
+            await setIceServers(settings.servers);
+          }
+        } catch (error) {
+          console.error('Error syncing servers with Rust:', error);
+        }
+      }
+    };
+
+    syncServersWithRust();
+  }, []);
+
+  // Функция для установки серверов в Rust
+  const setIceServers = async (servers: ServerConfig[]) => {
+    setIsLoading(true);
+    try {
+      await invoke('set_ice_servers', { servers });
+      console.log('ICE servers successfully set in Rust');
+      return true;
+    } catch (error) {
+      console.error('Failed to set ICE servers:', error);
+      toast({
+        title: "Ошибка",
+        description: "Не удалось установить ICE серверы",
+        variant: "destructive"
+      });
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Функция для получения текущих серверов из Rust
+  const getIceServers = async (): Promise<ServerConfig[]> => {
+    try {
+      const servers = await invoke<ServerConfig[]>('get_ice_servers');
+      return servers;
+    } catch (error) {
+      console.error('Failed to get ICE servers:', error);
+      return [];
+    }
+  };
+
+  return {
+    setIceServers,
+    getIceServers,
+    isLoading
+  };
+};
+
+// Обновите Settings компонент
+// В вашем Settings.tsx добавьте:
+
+// import { useIceServers } from '@/hooks/useIceServers';
+
+// const Settings = ({ onBack }: SettingsProps) => {
+//   // ... existing code ...
+  
+//   const { setIceServers: syncIceServers } = useIceServers();
+
+//   const handleSave = async () => {
+//     // Проверяем, что есть хотя бы один сервер
+//     if (!settings.servers || settings.servers.length === 0) {
+//       toast({
+//         title: "Ошибка",
+//         description: "Необходимо добавить хотя бы один STUN или TURN сервер",
+//         variant: "destructive"
+//       });
+//       return;
+//     }
+
+//     // Проверяем, что все серверы имеют корректные URL
+//     const invalidServers = settings.servers.filter(server => !server.url || server.url.trim() === '');
+//     if (invalidServers.length > 0) {
+//       toast({
+//         title: "Ошибка",
+//         description: "Все серверы должны иметь корректный URL",
+//         variant: "destructive"
+//       });
+//       return;
+//     }
+
+//     // Сохраняем настройки в localStorage
+//     localStorage.setItem('ssc-settings', JSON.stringify(settings));
+    
+//     // Синхронизируем с Rust
+//     const success = await syncIceServers(settings.servers);
+    
+//     if (success) {
+//       console.log('Settings saved and synced with Rust:', settings);
+//       toast({
+//         title: "Успешно",
+//         description: "Настройки сохранены и применены"
+//       });
+//       onBack();
+//     }
+//   };
+
+//   // ... rest of component
+// };

--- a/src/pages/GenerateQR.tsx
+++ b/src/pages/GenerateQR.tsx
@@ -13,16 +13,17 @@ interface GenerateQRProps {
   onBack: () => void;
   onConnected: () => void;
   autoGenerate?: boolean;
+  ttl?: number; // TTL в минутах
 }
 
-const GenerateQR = ({ onBack, onConnected, autoGenerate }: GenerateQRProps) => {
+const GenerateQR = ({ onBack, onConnected, autoGenerate, ttl: ttlMinutes = 5 }: GenerateQRProps) => {
   const [offer, setOffer] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
   const [answer, setAnswer] = useState('');
   const [awaitingAnswer, setAwaitingAnswer] = useState(false);
   // TTL для QR-кода (секунды)
-  const TTL = 300;
+  const TTL = ttlMinutes * 60;
   const [ttl, setTtl] = useState(TTL);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -451,6 +451,22 @@ const Settings = ({ onBack }: SettingsProps) => {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
+              {/* Предупреждение если нет TURN серверов */}
+              {(!settings.servers || settings.servers.filter(s => s.type === 'turn').length === 0) && (
+                <div className="p-4 bg-orange-900/30 border border-orange-500/50 rounded-lg">
+                  <div className="flex items-start space-x-3">
+                    <div className="w-2 h-2 bg-orange-500 rounded-full mt-2 flex-shrink-0"></div>
+                    <div>
+                      <p className="text-orange-300 font-medium mb-1">Внимание!</p>
+                      <p className="text-orange-200 text-sm">
+                        Не добавлено ни одного TURN сервера. Связь из под разных сетей не гарантирована. 
+                        Настоятельно рекомендуется добавить хотя бы один TURN сервер.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+              
               {(settings.servers || []).map((server) => (
                 <AnimatedContent
                 ease="bounce.out"


### PR DESCRIPTION
### PR: Add support for custom ICE servers and configurable QR code TTL

#### Changes:

* **Rust Backend (`src-tauri`)**:

  * Added `set_ice_servers` and `get_ice_servers` commands for setting and retrieving ICE server configurations.
  * Implemented global storage for custom ICE servers with validation checks.
  * Modified RTC configuration to use custom ICE servers if set, or default STUN servers otherwise.

* **Frontend (`React`)**:

  * Introduced a new hook `useIceServers` for managing ICE server configurations.
  * Synchronization of ICE servers between frontend settings (localStorage) and Rust backend on app initialization and settings save.
  * Updated `Settings.tsx` to handle ICE server validation, syncing, and user-friendly error messages.
  * Added support for configurable TTL (Time To Live) for QR codes with default of 5 minutes, adjustable via settings.

#### Motivation:

* Allow users to specify their own ICE server configurations, enhancing connectivity options.
* Provide flexibility for QR code expiration time, improving usability.

#### Affected Files:

* `src-tauri/src/lib.rs`
* `src-tauri/src/signaling.rs`
* `src-tauri/src/webrtc_peer.rs`
* `src/hooks/useIceServers.ts` (new)
* `src/pages/GenerateQR.tsx`
* `src/pages/Index.tsx`
* `src/pages/Settings.tsx`
