### PR TITLE
Enhance CI/CD workflow by adding Node.js and Rust setup steps

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -373,15 +373,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
       - name: Setup Java (for Gradle)
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: '17'                              # поддерживаемая версия
+          java-version: '17'
           cache: gradle
 
       - name: Setup Android SDK tools
-        uses: android-actions/setup-android@v3             # устанавливает sdkmanager и platform-tools :contentReference[oaicite:8]{index=8}
+        uses: android-actions/setup-android@v3
 
       - name: Install Android SDK Platforms & NDK
         run: |
@@ -392,28 +398,63 @@ jobs:
       - name: Set up NDK_HOME
         run: echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
 
+      - name: Setup Rust with Android targets
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: aarch64-linux-android
+
+      - name: Add Android Rust targets
+        run: |
+          rustup target add aarch64-linux-android
+          rustup target add armv7-linux-androideabi
+          rustup target add i686-linux-android
+          rustup target add x86_64-linux-android
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-android-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-android-cargo-
+
       - name: Install dependencies & build web assets
         run: |
           npm ci
           npm run build
 
-      - name: Install Tauri CLI
-        run: npm install -g @tauri-apps/cli@latest
+      - name: Install Tauri CLI locally
+        run: npm install --save-dev @tauri-apps/cli@latest
+
+      - name: Debug environment
+        run: |
+          echo "ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
+          echo "NDK_HOME: $NDK_HOME"
+          echo "Node version: $(node --version)"
+          echo "NPM version: $(npm --version)"
+          ls -la node_modules/.bin/ | grep tauri || echo "Tauri CLI not found"
 
       - name: Initialize Android target
         run: |
           cd src-tauri
-          tauri android init --ci                  # готовит Gradle конфиг :contentReference[oaicite:9]{index=9}
+          npx tauri android init --ci
         env:
           ANDROID_SDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}
+          NDK_HOME: ${{ env.NDK_HOME }}
 
       - name: Build release APK & AAB
         run: |
           cd src-tauri
-          tauri android build
+          npx tauri android build --apk --aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}
+          NDK_HOME: ${{ env.NDK_HOME }}
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updated the `ci-cd.yml` workflow to include steps for setting up Node.js and Rust with Android targets. Added caching for Rust dependencies and modified the Tauri CLI installation to be local. Improved the initialization and build commands for the Android target, ensuring a more robust and efficient build process.